### PR TITLE
removed progress bar from questions show

### DIFF
--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -7,5 +7,3 @@
     </div>
     <% end %>
 </div>
-
-<progress id="progress-bar" max="100" value="50"> 10% </progress>


### PR DESCRIPTION
- Removed progress bar from questions show because it's been decided it would go inside the navbar